### PR TITLE
Fixed joystick read routine.

### DIFF
--- a/src/apple2/input.inc
+++ b/src/apple2/input.inc
@@ -82,7 +82,6 @@ right:
     ora joyMask 
     eor #$ff
     sta joyMask                                 ; update the joy Mask with X digital
-    ldx #$00
     rts                                         ; return with joyMask in accumulator
 
 leave:

--- a/src/apple2/input.inc
+++ b/src/apple2/input.inc
@@ -40,44 +40,49 @@ xchk:                                           ; get bit 8 clear in c064 and c0
     bpl goY                                     ; bit 8 not set?
     nop                                         ; wast time
     inx                                         ; count the ticks
-    lda $c065                                   ; load up/down
+    bne :+                                      ; overflow?
+    dex                                         ; keep $ff
+:   lda $c065                                   ; load up/down
     bmi ychk                                    ;  
     bpl xchk                                    ; 
 ychk:
     iny                                         ; inc y counter
-    jmp xchk                                    ; goX
+    bne :+                                      ; overflow?
+    dey                                         ; keep $ff
+:   jmp xchk                                    ; goX
 
 goY:
     lda $c065                                   ; load up/down
     bmi ychk                                    ; bit 8 set?
 
     tya                                         ; y is the direction analog
-    cmp #$66                                    ; >= $66 is down
+    cmp #$60                                    ; >= $60 is down
     bcs down
-    cmp #$33                                    ; < $33 is up, $33-$65 is deadzone
+    cmp #$10                                    ; < $10 is up, rest is deadzone
     bcs doX
-    lda #KEY_UP                                 ; < $33 is KEY_UP digital
+    lda #KEY_UP                                 ; < $10 is KEY_UP digital
     bne :+
 down:
-    lda #KEY_DOWN                               ; >= $66 is KEY_DOWN digital
+    lda #KEY_DOWN                               ; >= $60 is KEY_DOWN digital
 :
     ora joyMask                                 ; update the mask
     sta joyMask                                 ; for the Y direction
 
 doX:
     txa                                         ; turn x into digital
-    cmp #$66                                    ; >= $66 is right
+    cmp #$60                                    ; >= $60 is right
     bcs right
-    cmp #$33                                    ; < $33 is left, rest is deadzone
+    cmp #$10                                    ; < $10 is left, rest is deadzone
     bcs leave
-    lda #KEY_LEFT                               ; < $33 is KEY_LEFT digital
+    lda #KEY_LEFT                               ; < $10 is KEY_LEFT digital
     bne :+
 right:
-    lda #KEY_RIGHT                              ; > $66 is KEY_RIGHT
+    lda #KEY_RIGHT                              ; > $60 is KEY_RIGHT
 :
     ora joyMask 
     eor #$ff
     sta joyMask                                 ; update the joy Mask with X digital
+    ldx #$00
     rts                                         ; return with joyMask in accumulator
 
 leave:


### PR DESCRIPTION
Depending on the actual joystick used on a real machine the timeout in question may be much longer than expected. Therefore a potential counter overflow must be taken into account.
The added overflow check made of course slowed down the timing loop so adjustments to the thresholds became necessary. Independently from that the deadzone was significantly increased as usual joysticks have quite some backlash around the center position.