### PR TITLE
Allow start with active 80-column display.

### DIFF
--- a/src/apple2.loader/loader.s
+++ b/src/apple2.loader/loader.s
@@ -111,8 +111,15 @@ PRESS_ANY_KEY:
         sta     READ_REF
         sta     CLOSE_REF
 
+        ; Turn off 80-column firmware
+        lda     VERSION
+        cmp     #$06        ; //e ?
+        bne     :+
+        lda     #$15
+        jsr     $C300
+
         ; Switch to hires page 2
-        bit     TXTCLR
+:       bit     TXTCLR
         bit     MIXCLR
         bit     HISCR
         bit     HIRES


### PR DESCRIPTION
With active 80-column display there's no way to activate hires page2. Instead of directly fiddling with 80COLSTORE it seems the cleanest way to disable the 80-column display via the official firmware entry point.

The ProDOS 8 Technical Reference Manual states in chapter 5.3.1.3 - 80-Column Text Card:

_80-column text cards -- and other Apple IIe features -- can be turned off_
_using the following sequence of instructions:_

 _LDA #$15     ;Character that turns off video firmware_
 _JSR $C300   ;Print it to the video firmware_
