### PR TITLE
Initialize backLayer.

### DIFF
--- a/src/apple2/penetrator.asm
+++ b/src/apple2/penetrator.asm
@@ -72,6 +72,8 @@ store:
     dex 
     bpl :-
 
+    sta backLayer                               ; set back layer to 0
+
     ldx #((BitMasksEnd - BitMasks) - 1)
 :
     lda BitMasks, x


### PR DESCRIPTION
The zeropage variable backLayer was uninitialized. The program only happened to work if $0090 happened to be $00 (or $01 ?) on startup.